### PR TITLE
Fix: incorrect text color when switching themes

### DIFF
--- a/docs/src/previews/avatar.svelte
+++ b/docs/src/previews/avatar.svelte
@@ -57,7 +57,7 @@
 			contenteditable
 			id="gh"
 			class=" w-auto border-b-2 border-neutral-600 bg-transparent px-1 pb-1 text-center text-2xl font-light
-			text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
+			dark:text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
 			bind:innerText={username}
 			spellcheck="false"
 		></span>

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -50,7 +50,7 @@
 <Preview>
 	<div class="mx-auto flex w-fit flex-col gap-2" {...group.root}>
 		<!-- svelte-ignore a11y_label_has_associated_control -- https://github.com/sveltejs/svelte/issues/15067 -->
-		<label {...group.label} class="font-semibold text-white">Layout</label>
+		<label {...group.label} class="font-semibold">Layout</label>
 		<div class="flex {isVert ? 'flex-col gap-1' : 'flex-row gap-3'}">
 			{#each items as i}
 				{@const item = group.getItem(i)}
@@ -71,7 +71,7 @@
 						{/if}
 					</div>
 
-					<span class="font-medium capitalize leading-none text-gray-100">
+					<span class="font-medium capitalize leading-none dark:text-gray-100 text-gray-600">
 						{i}
 					</span>
 				</div>


### PR DESCRIPTION
Radio Group and Avatar previews had incorrect text color, this small PR fixes it.
Before
![image](https://github.com/user-attachments/assets/29c0db56-0dc0-432a-abb1-e0f66052bd12)
After
![image](https://github.com/user-attachments/assets/4beef52c-a8e0-4594-81f2-9db5e0b4f270)
